### PR TITLE
Clean sub-directories with top level make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,4 +127,6 @@ create_netCDF_from_rawdata/gmted2010/mea.nc:
 	test -f create_netCDF_from_rawdata/gmted2010_modis-rawdata.nc || (cd create_netCDF_from_rawdata/gmted2010; chmod +x unpack.sh; ./unpack.sh)
 
 clean:
+	cd bin_to_cube; $(MAKE) clean
+	cd cube_to_target; $(MAKE) clean
 	rm -f modules_loaded.txt


### PR DESCRIPTION
Before this commit, calling make clean on the top-level Makefile would only
remove the module_load.sh file and would not recursively call the make clean's
of the sub-directories (mainly, bin_to_cube and cube_to_target).

Occasionally, especially when porting to a new system, it would be necessary to
make clean the sub-directories as they could be in a bad state (i.e. compiled
with a different compiler version/flavor), thus it being able to clean built
files in the sub-directories required one to manually cd into those directories
and call make clean.

This commit allows the ability for the top level make file to clean
subdirectories using a recursive $(MAKE) call.