### PR TITLE
Greatly simplfy the setting of LDFLAGS and FFLAGS using nc-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,7 @@ topo_file=cube_to_target/output/$(output_grid)_$(case_name).nc
 #
 #********************************
 #
-all: load_modules $(smooth_topo_file) $(topo_file) 
-#
-# load appropriate modules (machine specific)
-#
-load_modules:
-	echo "module purge"                 >  module_load.sh
-	echo "module load $(module_gnu)"    >> module_load.sh
-	echo "module load $(module_netCDF)" >> module_load.sh
-	source module_load.sh
+all: $(smooth_topo_file) $(topo_file)
 
 create_netCDF_from_rawdata/$(raw_data)-rawdata.nc:
 	test -f $(create_netCDF_from_rawdata/$(raw_data)-rawdata.nc) ||(cd create_netCDF_from_rawdata; make)

--- a/bin_to_cube/Makefile
+++ b/bin_to_cube/Makefile
@@ -7,7 +7,7 @@ RM = rm
 .SUFFIXES: .F90 .o
 
 .F90.o:
-	$(FC) $(FFLAGS) $<
+	$(FC) $(FFLAGS) $< $(LDFLAGS)
 
 #------------------------------------------------------------------------
 # Default rules and macros

--- a/cube_to_target/Makefile
+++ b/cube_to_target/Makefile
@@ -7,7 +7,7 @@ RM = rm
 .SUFFIXES: .F90 .o
 
 .F90.o:
-	$(FC) $(FFLAGS) $<
+	$(FC) $(FFLAGS) $< $(LDFLAGS)
 
 #------------------------------------------------------------------------
 # Default rules and macros

--- a/machine_settings.make
+++ b/machine_settings.make
@@ -1,102 +1,33 @@
 #
-# set machine
-#
-export machine=cheyenne
-#export machine=thorodin
-ifeq ($(machine),thorodin)
-  export module_gnu=compiler/gnu/8.1.0
-  export module_netCDF=tool/netcdf/4.6.1/gcc-8.1.0
-#  export module_python="lang/python/3.7.0"
-endif
-ifeq ($(machine),cheyenne)
-#
-# can't get module load to work on Cheyenne
-#
-  export module_gnu="gnu/9.1.0"
-  export module_netCDF="netcdf/4.7.4"
-#  module spider gdal
-endif
-#
 # set python path
 #
 export python_path=/usr/local/anaconda-2.4.0/bin/
-#
-# Fortran settings
-#
-ifeq ($(machine),thorodin)
-  FC=gfortran
-endif
-ifeq ($(machine),cheyenne)
-  FC=gfortran
-endif
-#FC = nagfor
-#FC = pgf95
+
 DEBUG=FALSE
 
+FC = $(shell nc-config --fc)
+LDFLAGS = $(shell nc-config --flibs)
+FFLAGS = -c $(shell nc-config --fflags)
 
-
-# default settings
-# LIB_NETCDF := /opt/local/lib
-# INC_NETCDF := /opt/local/include
 #------------------------------------------------------------------------
-# GFORTRAN
+# Gfortran
 #------------------------------------------------------------------------
-#
-ifeq ($(FC),gfortran)
+ifeq ($(findstring gfortran, $(FC)),gfortran)
+    ifneq ($(findstring pgfortran, $(FC)),pgfortran)
+      FFLAGS  += -fdollar-ok
 
-#  ifeq ($(machine),thorodin)
-##    INC_NETCDF=/usr/local/netcdf-gcc-g++-gfortran/include
-#    INC_NETCDF=/usr/local/netcdf-c-4.6.1-f-4.4.4-gcc-g++-gfortran-8.1.0/include
-###    INC_NETCDF=/usr/local/netcdf-c-4.6.1-f-4.4.4-gcc-g++-gfortran-4.8.5/include
-#
-##    LIB_NETCDF=/usr/local/netcdf-gcc-g++-gfortran/lib
-#    LIB_NETCDF=/usr/local/netcdf-c-4.6.1-f-4.4.4-gcc-g++-gfortran-8.1.0/lib
-##    LIB_NETCDF=/usr/local/netcdf-c-4.6.1-f-4.4.4-gcc-g++-gfortran-4.8.5/lib
-#  endif
-#
-  ifeq ($(machine),cheyenne)
-    LIB_NETCDF=/glade/u/apps/ch/opt/netcdf/4.6.3/gnu/9.1.0/lib
-    INC_NETCDF=/glade/u/apps/ch/opt/netcdf/4.6.3/gnu/9.1.0/include
-#    LIB_NETCDF=/glade/u/apps/ch/opt/netcdf/4.7.4/gnu/9.1.0/
-#    INC_NETCDF=/glade/u/apps/ch/opt/netcdf/4.7.4/gnu/9.1.0/include/
-  endif
-
-
-#  LDFLAGS= -L$(LIB_NETCDF)  -lnetcdf -lnetcdff
-#  FFLAGS= -c  -fdollar-ok  -I$(INC_NETCDF) 
-
-  #
-  # module purge
-  # module load compiler/gnu/8.1.0
-  #
-#  LIB_NETCDF = $(NETCDF_PATH)/lib
-#  INC_NETCDF = $(NETCDF_PATH)/include
-  LDFLAGS= -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-  FFLAGS= -c  -fdollar-ok  -I$(INC_NETCDF)
-
-  ifeq ($(DEBUG),TRUE)
-#   FFLAGS += --chk aesu  -Cpp --trace
-    FFLAGS += -Wall -fbacktrace -fbounds-check -fno-range-check
-  else
-    FFLAGS += -O
+      ifeq ($(DEBUG),TRUE)
+        FFLAGS += -Wall -fbacktrace -fbounds-check -fno-range-check
+      else
+        FFLAGS += -O
+    endif
   endif
 endif
 
 #------------------------------------------------------------------------
 # NAG
 #------------------------------------------------------------------------
-ifeq ($(FC),nagfor)
-
-#  INC_NETCDF :=/usr/local/netcdf-gcc-nag/include
-#  LIB_NETCDF :=/usr/local/netcdf-pgi/lib
-
-  INC_NETCDF :=/usr/local/netcdf-gcc-nag/include
-  LIB_NETCDF :=/usr/local/netcdf-gcc-nag/lib
-
-  LDFLAGS = -L$(LIB_NETCD)F -lnetcdf -lnetcdff
-  FFLAGS   := -c  -I$(INC_NETCDF)
-
-
+ifeq ($(findstring nagfor, $(FC)),nagfor)
   ifeq ($(DEBUG),TRUE)
     FFLAGS += -g -C
   else
@@ -104,31 +35,20 @@ ifeq ($(FC),nagfor)
   endif
 
 endif
+
 #------------------------------------------------------------------------
 # PGF95
 #------------------------------------------------------------------------
-#
-# setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/usr/local/netcdf-4.1.3-gcc-4.4.4-13-lf9581/lib
-#
-
-ifeq ($(FC),pgf95)
-  INC_NETCDF :=/opt/local/include
-  LIB_NETCDF :=/opt/local/lib
-
-  LDFLAGS = -L$(LIB_NETCDF) -lnetcdf -lnetcdff
-  FFLAGS   := -c -Mlarge_arrays -I$(INC_NETCDF)
-
+ifeq ($(findstring pgf95, $(FC)),pgf95)
+  FFLAGS += -Mlarge_arrays
 
   ifeq ($(DEBUG),TRUE)
     FFLAGS += -g -Mbounds -traceback -Mchkfpstk
   else
     FFLAGS += -O
   endif
-
 endif
 
-export INC_NETCDF
-#export LIB_NETCDF
 export LDFLAGS
 export FFLAGS
 export FC


### PR DESCRIPTION
This merge greatly simplifies the machine_settings.make file by
using the nc-config, which determines the compilers and locations for the active
NetCDF implementation.

First, it removes any references to a machine. This means, the user no longer
needs to manually specific the machine that they are on, or the paths to the
NetCDF installation directory.

Next, it sets FC, LDFLAGS and FFLAGS using the nc-config tool.

The -c flag was moved in the top level FFLAGS, as (I believe) all modern
C and Fortran compilers use for building and object (.o file).

Lastly, for the portion of the machine_settings.make that adds compiler
specific flags, it updates the ifeq statements to use findstring, as the
nc-config --fc might return the path of the compiler rather than just the
compiler name. This might pose a problem if the same string is within $FC, like
pgfortran and gfortran. There might be a better make tool for determine the
difference, but for now, lets just explicity check for pgfortran for gfortran
for simplicity.

Depending on a user's installation of NetCDF, users will need to
manually add flags that are not included in nc-config --flibs (such as
-lpnetcdf for NetCDF that is built with MPI).

Users will still need to edit the Makefile to point to their copy of
gmted2010_modis-ncube3000-stitch.nc for the intermediate_cube_sphere_file.