### PR TITLE
Remove '$' from variables, add to .gitignore and add MPAS Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.mod
 *.nl
 *.nc
+*.dat
+*.swp
+*.swo
+cube_to_target/cube_to_target
+bin_to_cube/bin_to_cube

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ include machine_settings.make
 raw_data=gmted2010_modis
 
 #intermediate_cubed_sphere_file=/project/amp/juliob/topo-data/gmted2010_modis-ncube3000-stitch.nc
-intermediate_cubed_sphere_file=/glade/p/cgd/amp/aherring/grids/topo/gmted2010_modis-ncube3000-stitch.nc
+#intermediate_cubed_sphere_file=/glade/p/cgd/amp/aherring/grids/topo/gmted2010_modis-ncube3000-stitch.nc
+intermediate_cubed_sphere_file=/shared/wmr/mcurry/cesmdata/topo/gmted2010_modis-ncube3000-stitch.nc
+intermediate_cubed_sphere_file=/shared/wmr/mcurry/cesmdata/topo/gmted2010_bedmachine-ncube6000.nc
+
 ncube_sph_smooth_fine=001
 # MulG: valid options are '_MulG' or ''
 #MulG=''

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -154,11 +154,11 @@ program convterr
   integer, allocatable :: isg(:)
 
   character(len=1024) :: grid_descriptor_fname,intermediate_cubed_sphere_fname,output_fname,  externally_smoothed_topo_file
-  character(len=1024) :: output_grid, ofile$, proctag$, smooth_fname, remap_fname, smoothprm$, rdgwin$, rdglist_fname
+  character(len=1024) :: output_grid, ofile, proctag, smooth_fname, remap_fname, smoothprm, rdgwin, rdglist_fname
   character(len=1024) :: rrfactor_fname
 
-  character(len=8)  :: date$
-  character(len=10) :: time$
+  character(len=8)  :: date
+  character(len=10) :: time
 
 !+++ARH
   character(len=1024) :: cube_file
@@ -273,24 +273,24 @@ program convterr
          !----------------------------------------------------------------------
          !  Final gridded nc file 
          !---------------------------
-         call DATE_AND_TIME( DATE=date$,TIME=time$)
+         call DATE_AND_TIME( DATE=date,TIME=time)
 
-         proctag$=' '
+         proctag=' '
          if (lb4b_with_cesm2) then
-            proctag$ = trim(proctag$)//'_CESM2'
+            proctag = trim(proctag)//'_CESM2'
          end if
          if (luse_multigrid) then
-            proctag$ = trim(proctag$)//'_MulG'
+            proctag = trim(proctag)//'_MulG'
          end if
          if (luse_prefilter) then
-            proctag$ = trim(proctag$)//'_PF'
+            proctag = trim(proctag)//'_PF'
          end if
 
          if (lregional_refinement) then
-            proctag$ = trim(proctag$)//'_RR'
+            proctag = trim(proctag)//'_RR'
          end if
 
-         write( smoothprm$ , &
+         write( smoothprm , &
              "('_nc',i0.4,'_Co',i0.3,'_Fi',i0.3 )" ) & 
          ncube, ncube_sph_smooth_coarse, ncube_sph_smooth_fine
 
@@ -299,24 +299,24 @@ program convterr
              write(*,*) "nwindow_halfwidth must be >0",nwindow_halfwidth
              stop
            endif
-         write( rdgwin$ , &
+         write( rdgwin , &
              "('_Nsw',i0.3 )" ) nwindow_halfwidth  
          else
-           rdgwin$ = '_NoAniso'
+           rdgwin = '_NoAniso'
          end if  
          
-         write(*,*)" Smooth ", trim(smoothprm$)
-         write(*,*)" Procs  ", trim(proctag$)
-         write(*,*)" Ridge  ", trim(rdgwin$)
+         write(*,*)" Smooth ", trim(smoothprm)
+         write(*,*)" Procs  ", trim(proctag)
+         write(*,*)" Ridge  ", trim(rdgwin)
 
 
-         smooth_fname  = './inputdata/smooth_topo_cube/topo_smooth'//trim(smoothprm$)//trim(proctag$)//'_v02.dat'
-         rdglist_fname = './inputdata/RdgList'//trim(smoothprm$)//trim(proctag$)//trim(rdgwin$)//'.dat'
-         remap_fname   = './output/remap'//trim(smoothprm$)//trim(proctag$)//trim(rdgwin$)//'.dat'
-         output_fname  = './output/'//trim(output_grid)//trim(smoothprm$)//trim(proctag$)//trim(rdgwin$)//'.nc'
+         smooth_fname  = './inputdata/smooth_topo_cube/topo_smooth'//trim(smoothprm)//trim(proctag)//'_v02.dat'
+         rdglist_fname = './inputdata/RdgList'//trim(smoothprm)//trim(proctag)//trim(rdgwin)//'.dat'
+         remap_fname   = './output/remap'//trim(smoothprm)//trim(proctag)//trim(rdgwin)//'.dat'
+         output_fname  = './output/'//trim(output_grid)//trim(smoothprm)//trim(proctag)//trim(rdgwin)//'.nc'
 
-!         remap_fname   = './output/remap'//trim(smoothprm$)//trim(proctag$)//trim(rdgwin$)//'_'//date$//'.dat'
-!         output_fname  = './output/'//trim(output_grid)//trim(smoothprm$)//trim(proctag$)//trim(rdgwin$)//'_'//date$//'.nc'
+!         remap_fname   = './output/remap'//trim(smoothprm)//trim(proctag)//trim(rdgwin)//'_'//date//'.dat'
+!         output_fname  = './output/'//trim(output_grid)//trim(smoothprm)//trim(proctag)//trim(rdgwin)//'_'//date//'.nc'
 
 
 

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -117,7 +117,7 @@ subroutine find_local_maxes ( terr_dev, ncube, nhalo, nsb, nsw ) !, npeaks, peak
     !REAL(KIND=dbl_kind)  :: lon_r8, lat_r8, cosll, dx, dy, dcube2, ampfsm,dbet,dalp,diss,diss00
     REAL(KIND=dbl_kind)  :: thsh
 
-    CHARACTER(len=1024) :: ofile$,ve$
+    CHARACTER(len=1024) :: ofile,ve
 
 !---------------------------------------------------------------------------------------
 !  B E G I N   C A L C U L A T I O N S
@@ -200,7 +200,7 @@ write(*,*) " SHAPE ", shape( peaks%i )
 !===================================================================================================
 
 subroutine find_ridges ( terr_dev, terr_raw, ncube, nhalo, nsb, nsw,  & 
-                         ofile$, &
+                         ofile, &
                          lregional_refinement, rr_factor )
 !------------------------------------------------
 !  INPUTS.
@@ -220,7 +220,7 @@ subroutine find_ridges ( terr_dev, terr_raw, ncube, nhalo, nsb, nsw,  &
        INTEGER (KIND=int_kind), INTENT(IN) :: ncube, nhalo, nsb, nsw 
 
        LOGICAL, intent(IN), OPTIONAL ::  lregional_refinement
-       CHARACTER(len=1024), intent(IN)  :: ofile$
+       CHARACTER(len=1024), intent(IN)  :: ofile
 
        INTEGER (KIND=int_kind) :: i,j,np,ncube_halo,ipanel,N,norx,nory,ip,ipk,npeaks
        INTEGER (KIND=int_kind) :: nswr,nsbr
@@ -250,7 +250,7 @@ subroutine find_ridges ( terr_dev, terr_raw, ncube, nhalo, nsb, nsw,  &
 
     REAL(KIND=dbl_kind)  :: lon_r8, lat_r8, cosll, dx, dy, dcube2, ampfsm,dbet,dalp,diss,diss00
 
-    CHARACTER(len=1024) :: ve$
+    CHARACTER(len=1024) :: ve
 
 
     do_refine = .FALSE.
@@ -360,7 +360,7 @@ write(*,*) " SHAPE ", shape( peaks%i )
 
 #if 1
 
-    OPEN (unit = 31, file= trim(ofile$) ,form="UNFORMATTED" )
+    OPEN (unit = 31, file= trim(ofile) ,form="UNFORMATTED" )
 
     write(31) ncube,ncube_halo
     write(31) xv,yv
@@ -718,7 +718,7 @@ end subroutine ANISO_ANA
 !====================================
    subroutine remapridge2target(area_target,target_center_lon,target_center_lat,  &
          weights_eul_index_all,weights_lgr_index_all,weights_all,ncube,jall, &
-         nreconstruction,ntarget,nhalo,nsb,nsw,nsmcoarse,nsmfine,ofile$, & 
+         nreconstruction,ntarget,nhalo,nsb,nsw,nsmcoarse,nsmfine,ofile, & 
          lzerovalley,luse_multigrid,luse_prefilter,lb4b_with_cesm2, &
          lregional_refinement,rr_factor )
 
@@ -731,7 +731,7 @@ end subroutine ANISO_ANA
       integer , intent(in) :: ncube,jall,nreconstruction,ntarget,nhalo,nsb,nsw,nsmcoarse,nsmfine
       real(r8), intent(in) :: area_target(ntarget),target_center_lon(ntarget),target_center_lat(ntarget)
       logical, intent(in)  :: lzerovalley,luse_multigrid,luse_prefilter,lb4b_with_cesm2
-      CHARACTER(len=1024),intent(in) :: ofile$
+      CHARACTER(len=1024),intent(in) :: ofile
 
         logical, optional, intent(in)  :: lregional_refinement
         real(r8) , optional, intent(in) :: rr_factor( ncube, ncube, 6 )
@@ -752,8 +752,8 @@ end subroutine ANISO_ANA
       real(KIND=dbl_kind), dimension(ncube*ncube*6) :: cwghtC , itrgtC, fallqC, riseqC, rwpksC
       real(KIND=dbl_kind), dimension(ncube*ncube)   :: dA
 
-      character(len=8)  :: date$
-      character(len=10) :: time$
+      character(len=8)  :: date
+      character(len=10) :: time
       logical :: do_refine
 
 !----------------------------------------------------------------------------------------------------
@@ -1015,7 +1015,7 @@ end subroutine ANISO_ANA
 
      call latlonangles (target_center_lon,target_center_lat,ntarget)
 
-OPEN (unit = 911, file= trim(ofile$) ,form="UNFORMATTED" )
+OPEN (unit = 911, file= trim(ofile) ,form="UNFORMATTED" )
 
 write(911) ncube,npeaks
 write(911) mxdisC
@@ -1690,7 +1690,7 @@ subroutine paintridgeoncube ( ncube,nhalo,nsb,nsw , terr  )
      !bgnxg_tiles = -9999._r8
     end where
 
-    !OPEN (unit = 611, file= trim(tfile$) ,form="UNFORMATTED" )
+    !OPEN (unit = 611, file= trim(tfile) ,form="UNFORMATTED" )
     OPEN (unit = 611, file= 'RidgeTile.dat' ,form="UNFORMATTED" )
     write( 611 ) ntarget,ntiles
     write( 611 ) error_tiles

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -291,7 +291,7 @@ CONTAINS
 
     REAL(KIND=dbl_kind) :: RSM_scl, smoo,irho,volt0,volt1,volume_after,volume_before,wt1ps
 
-    CHARACTER(len=1024) :: ofile$
+    CHARACTER(len=1024) :: ofile
 
     write(*,*) " NCUBE !!! " , ncube
 

--- a/experiment_settings.make
+++ b/experiment_settings.make
@@ -22,7 +22,7 @@
 #
 # 	smooth_topo_file_dir
 #
-export case=fv_0.9x1.25_Co060_ridge
+#export case=fv_0.9x1.25_Co060_ridge
 #export case=fv_1.9x2.5_Co0120_ridge
 #export case=fv_4x5_Co0240_ridge
 #export case=fv_10x15_Co0480_ridge
@@ -37,6 +37,8 @@ export case=fv_0.9x1.25_Co060_ridge
 #export case=ne480pg2_Co0008_ridge
 #export case=mpas_120_Co060_ridge
 #export case=mpas_480_Co240_ridge
+#export case=mpas_60-3-cal_ridge
+export case=mpas_15-3-conus_Co009_ridge
 #
 # Experimental setups
 #
@@ -473,6 +475,32 @@ ifeq ($(case),mpas_480_Co240_ridge)
   export rdgwin=_Nsw$(nwindow_halfwidth)
   export stitch=-stitch
   export ncube=3000
+  case_found=
+endif
+
+ifeq ($(case),mpas_60-3-cal_ridge)
+  export ncube_sph_smooth_coarse=033
+  export output_grid=mpas_60_to_3
+  export grid_descriptor_fname=$(PWD)/cube_to_target/inputdata/grid-descriptor-file/mpasa60-3.california.SCRIP.nc
+  export nwindow_halfwidth=023
+  export rdgwin=_Nsw$(nwindow_halfwidth)
+  export stitch=-stitch
+  export ncube=3000
+  export lregional_refinement=.true.
+  export rrfac_max=020
+  case_found=
+endif
+
+ifeq ($(case),mpas_15-3-conus_Co009_ridge)
+  export ncube_sph_smooth_coarse=009
+  export output_grid=mpas_15-3
+  export grid_descriptor_fname=$(PWD)/cube_to_target/inputdata/grid-descriptor-file/mpasa15-3.conus.desc_SCRIP.210504.nc
+  export nwindow_halfwidth=006
+  export rdgwin=_Nsw$(nwindow_halfwidth)
+  export stitch=-stitch
+  export ncube=3000
+  export lregional_refinement=.true.
+  export rrfac_max=005
   case_found=
 endif
 

--- a/machine_settings.make
+++ b/machine_settings.make
@@ -14,8 +14,6 @@ FFLAGS = -c $(shell nc-config --fflags)
 #------------------------------------------------------------------------
 ifeq ($(findstring gfortran, $(FC)),gfortran)
     ifneq ($(findstring pgfortran, $(FC)),pgfortran)
-      FFLAGS  += -fdollar-ok
-
       ifeq ($(DEBUG),TRUE)
         FFLAGS += -Wall -fbacktrace -fbounds-check -fno-range-check
       else


### PR DESCRIPTION
This PR has a commits which has some general cleanup of the code.

The first commit removes '$' from variables, and thus also removes the `-fdollar-ok` when compiling with gfortran. This simplifies compiling a bit more for users, as users who compiling with an MPI installtion (e.g. the `mpifort` executable), the `machine_settings.make` file would not add `-fdollar-ok` to the FFLAGS. Rather than adding a another case for mpifort (which may be any compiler), just remove the '$' from variable names.

Another commit ignores .dat files that are generated by this tool, the cube_to_target and bin_to_cube  executables and other files that should not be included when using `git status` (e.g. `.swp, .swo` vim files).

Lastly, it adds a reference to the cube sphere on the MMM file systems and adds the MPAS 15-3 km and MPAS 60-3 km cases to `experiment_settings.make`.