### PR TITLE
This simply changes all instances of NF_64BIT_OFFSET -> NF_64BIT_DATA

### DIFF
--- a/bin_to_cube/bin_to_cube.F90
+++ b/bin_to_cube/bin_to_cube.F90
@@ -727,7 +727,7 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
   end do
   
   WRITE(*,*) "Create NetCDF file for output: ", TRIM(output_file)
-  ncstat = nf_create (TRIM(output_file), NF_64BIT_OFFSET,nc_grid_id)
+  ncstat = nf_create (TRIM(output_file), NF_64BIT_DATA,nc_grid_id)
   call handle_err(ncstat)
   
   ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'title',len_trim(grid_name), grid_name)

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1233,7 +1233,7 @@ program convterr
     !  Create NetCDF file for output
     !
     print *,"Create NetCDF file for output"
-    status = nf_create (trim(output_fname), NF_64BIT_OFFSET , foutid)
+    status = nf_create (trim(output_fname), NF_64BIT_DATA, foutid)
     if (status .ne. NF_NOERR) call handle_err(status)
     !
     ! Create dimensions for output
@@ -2003,7 +2003,7 @@ program convterr
     !  Create NetCDF file for output
     !
     print *,"Create NetCDF file for output"
-    status = nf_create (fout, NF_64BIT_OFFSET , foutid)
+    status = nf_create (fout, NF_64BIT_DATA, foutid)
     if (status .ne. NF_NOERR) call handle_err(status)
     !
     ! Create dimensions for output

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -764,7 +764,7 @@ subroutine wrtncdf_topo_smooth_data(ncube,n,terr_sm,terr_dev,landfrac,output_fna
   !  Create NetCDF file for output
   !
   print *,"Create NetCDF file for output: ",trim(output_fname)
-  status = nf_create (trim(output_fname), NF_64BIT_OFFSET , foutid)
+  status = nf_create (trim(output_fname), NF_64BIT_DATA, foutid)
   if (status .ne. NF_NOERR) call handle_err(status)
   !
   ! Meta data for CESM compliance

--- a/cube_to_target/write_ncoutput.F90
+++ b/cube_to_target/write_ncoutput.F90
@@ -72,7 +72,7 @@ subroutine wrtnc2_unstructured(n,terr,sgh,sgh30,landm_coslat,lon,lat,area,output
     !  Create NetCDF file for output
     !
     print *,"Create NetCDF file for output"
-    status = nf_create (fout, NF_64BIT_OFFSET , foutid)
+    status = nf_create (fout, NF_64BIT_DATA, foutid)
     if (status .ne. NF_NOERR) call handle_err(status)
     !
     ! Create dimensions for output


### PR DESCRIPTION
This change is needed for very high resolution cases, where we may have >4GB in a single variable.  It should work fine for any resolution, though.

We may need to do another change later to make 'ncube_sph_smooth_coarse' a namelist variable, or to change how it's calculated, as it doesn't work out of the box at 3.75km grids.  We're testing now with a hard-coded value of 5.  That's not in this PR though, just another thing for these ultra-high resolution cases.