### PR TITLE
remove the exact integration for condition (abs(yseg(1) -yseg(2))<fuz…

### DIFF
--- a/cube_to_target/remap.F90
+++ b/cube_to_target/remap.F90
@@ -1093,7 +1093,8 @@ end function paint_sg_field
 
             if (xseg(1).EQ.xseg(2))then
               slope = bignum
-            else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
+           !else if (abs(yseg(1) -yseg(2))<fuzzy_width) then !remove the exact integration
+            else if (.false.) then
               slope = 0.0
             else
               slope    = (yseg(2)-yseg(1))/(xseg(2)-xseg(1))
@@ -1196,7 +1197,8 @@ end function paint_sg_field
 !    if (fuzzy(abs(xseg(1) -xseg(2)),fuzzy_width)==0)then
     if (xseg(1).EQ.xseg(2))then
       weights = 0.0D0
-    else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
+    !else if (abs(yseg(1) -yseg(2))<fuzzy_width) then !remove the exact integration
+    else if (.false.) then
       !
       ! line segment parallel to latitude - compute weights exactly
       !


### PR DESCRIPTION
This is to fix the issue #62 to avoid the negative weights in some corner cases.

The current practice is to retain the exact integration algorithm, but never enable it—that is, according to @PeterHjortLauritzen 's instructions mentioned in #62 :
```
In remamp.F90 change:
    else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
to
    else if (.false.) then
```
